### PR TITLE
Create path if it does not exist; Fixes #55

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 // Load modules
 
 var Crypto = require('crypto');
-var Fs = require('fs');
+var Fs = require('fs-extra');
 var Path = require('path');
 var Stream = require('stream');
 
@@ -161,7 +161,7 @@ internals.GoodFile.prototype.init = function (stream, emitter, callback) {
 
 internals.GoodFile.prototype._buildWriteStream = function () {
 
-    var result = Fs.createWriteStream(this.getFile(), { flags: 'a', end: false, encoding: 'utf8' });
+    var result = Fs.createOutputStream(this.getFile(), { flags: 'a', end: false, encoding: 'utf8' });
     var self = this;
 
     result.once('error', function (err) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "big-time": "1.0.x",
+    "fs-extra": "0.24.0",
     "good-squeeze": "2.x.x",
     "hoek": "2.x.x",
     "joi": "5.x.x",


### PR DESCRIPTION
Just short of writing all the logic ourselves, this fix uses [fs-extra](https://www.npmjs.com/package/fs-extra)'s `createOutputStream` method to create the write stream instead of the native `createWriteStream` method.

In his own words, "Exactly like `createWriteStream`, but if the directory does not exist, it's created.".

You can read more about this method [here](https://github.com/jprichardson/node-fs-extra#createoutputstreamfile-options).

As a side note, Express' Morgan package (the Express equivalent of Good, which I'm sure you know), allows you to pass in the stream directly. This allows users to control whether they want to use `fs` or `fs-extra` (or whatever else for that matter) to create the write stream. Adding such an option to Good might lead to a more ideal solution.